### PR TITLE
删除glfw的导入

### DIFF
--- a/shader.py
+++ b/shader.py
@@ -5,7 +5,6 @@ import PIL.Image
 import numpy as np
 from OpenGL.GL import *
 from OpenGL.GL.shaders import compileShader, compileProgram
-import glfw
 
 
 class Texture:


### PR DESCRIPTION
如题，删除了`shader.py`内暂时似乎没有用到的`import glfw`
这将导致必须额外安装glfw，与`README`不符